### PR TITLE
add a setup.py for pip support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='pykeylogger',
+      version='1.0',
+      description='Keylogger for linux using xlib',
+      author='Andrew Moffat',
+      author_email='andrew@formconstantdance.org',
+      url='https://github.com/amoffat/pykeylogger',
+      packages=['pykeylogger'],
+      package_dir={'pykeylogger': '.'},
+      classifiers='License :: OSI Approved :: BSD License',
+     )


### PR DESCRIPTION
This does install lib/python2.7/site-packages/pykeylogger/setup.py, but that didn't bother me. I just preferred being able to have a pip requirements line over having to munge sys.path or mix your files among mine.

Thanks for publishing your code!